### PR TITLE
Update model weights download links

### DIFF
--- a/_model_exploration/README.md
+++ b/_model_exploration/README.md
@@ -39,7 +39,7 @@ Here is the ordered procedures performed during the project:
   * [2. Inference](#2-inference)
   * [3. Post-processing](#3-post-processing)
 
-Please find here the model weights: https://sftpgo.stdl.ch/web/client/pubshares/2HvZAv4VegLzxmXSPbmUeb/browse. The models correspond to the ones evaluated in Figure 19 of the [technical documentation](https://tech.stdl.ch/PROJ-SOILS/#61-evaluation).
+The weights of `HEIG-VD-original` model mentioned in the [technical documentation](https://tech.stdl.ch/PROJ-SOILS) can be found [here](../data/models/heigvd).
 
 ## Evaluation Pipeline
 

--- a/data/models/heigvd/model_checkpoint_download_link.txt
+++ b/data/models/heigvd/model_checkpoint_download_link.txt
@@ -1,1 +1,1 @@
-https://sftpgo.stdl.ch/web/client/pubshares/2HvZAv4VegLzxmXSPbmUeb/browse
+https://data.stdl.ch/proj-soils/model-weights/heigvd/M2F_ViTlarge_best_mIoU_iter_160000.pth

--- a/data/models/mix16/model_checkpoint_download_link.txt
+++ b/data/models/mix16/model_checkpoint_download_link.txt
@@ -1,1 +1,1 @@
-https://sftpgo.stdl.ch/web/client/pubshares/zMJcebJqsmWsqeMJ6vw9WK/browse
+https://data.stdl.ch/proj-soils/model-weights/mix16/best_mIoU_iter_428628.pth


### PR DESCRIPTION
Model weights files have been copied to the Open Data S3 bucket. Download links have been updated accordingly.